### PR TITLE
remove rounded corner for svg @ all screen sizes

### DIFF
--- a/src/assets/ro 1.svg
+++ b/src/assets/ro 1.svg
@@ -1,4 +1,4 @@
-<svg width="535" height="536" viewBox="0 0 535 536" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="500" height="500" viewBox="15 15 500 500" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 <rect y="0.859375" width="535" height="535" fill="url(#pattern0_3309_3926)"/>
 <defs>
 <pattern id="pattern0_3309_3926" patternContentUnits="objectBoundingBox" width="1" height="1">

--- a/src/components/about/about.css
+++ b/src/components/about/about.css
@@ -216,7 +216,8 @@
     order: -1;
   }
   #ro img {
-    border-radius: 1rem;
+    /* remove rounded corners for mobile screen */
+    /* border-radius: 1rem; */
     max-width: 100%;
   }
 

--- a/src/components/about/about.jsx
+++ b/src/components/about/about.jsx
@@ -143,7 +143,6 @@ const about = () => {
           <img src = {ro}/>
         </div>
       </div>
-    
     </div>
   )
 }


### PR DESCRIPTION
SVG itself was rounded so had to edit the SVG by cropping slightly to remove the out the rounded corners. Changed border radius for mobile screen size.